### PR TITLE
Use base64 encoding for usernames in http headers (shinyproxy specific)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     tools,
     withr
 Suggests: 
+    base64enc,
     kableExtra,
     knitr,
     pkgload,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.1.0.9004
+Version: 0.1.0.9006
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,15 @@
 # clinsight (development version)
 
+## Changed 
+
 - Added `pkgdown` GHA workflow to automatically update documentation site with PRs & pushes to `main` and `dev`
 - Generalized `merge_meta_with_data()` to allow user-defined processing functions.
 - Added a feature where, in applicable tables, a user can navigate to a form by double-clicking a table row.
 - Fixed warnings in `apply_edc_specific_changes` due to the use of a vector within `dplyr::select`.
+
+## Bug fixes
+
+- When using the `shinyproxy` deployment configuration, the user name is now expected to be base64 encoded, and will now be base64 encoded by `clinsight` by default, so that the app can also handle non-ASCII signs in user names that are stored in HTTP headers. To display the user name correctly, use base64 encoding in the `application.yml` in ShinyProxy settings (for example: `http-headers.X_SP_USERNAME: "#{T(java.util.Base64).getEncoder().encodeToString(oidcUser.getFullName().getBytes())}"`).
 
 # clinsight 0.1.0
 

--- a/R/app_authentication.R
+++ b/R/app_authentication.R
@@ -151,7 +151,7 @@ authenticate_server <- function(
     ),
     http_headers = reactiveValues(
       user = session$request$HTTP_X_SP_USERID,
-      name = session$request$HTTP_X_SP_USERNAME,
+      name = decode_base64(session$request$HTTP_X_SP_USERNAME),
       roles = get_valid_roles(session$request$HTTP_X_SP_USERGROUPS, all_roles),
       sites = all_sites
     ),

--- a/R/fct_utils.R
+++ b/R/fct_utils.R
@@ -738,6 +738,7 @@ dblclick_to_form <- function(bttn_ns) {
 decode_base64 <- function(
     x
 ){
+  stopifnot("base64enc is not installed" = rlang::is_installed("base64enc"))
   if(is.null(x)) return(x)
   stopifnot(is.character(x))
   decoded <- base64enc::base64decode(x)

--- a/R/fct_utils.R
+++ b/R/fct_utils.R
@@ -717,3 +717,41 @@ dblclick_to_form <- function(bttn_ns) {
     "document.getElementById(", deparse(NS(bttn_ns, "go_to_form")), ").click();",
     "})"
   )}
+
+#' Decode a base64 encoded string.
+#'
+#' Used to decode base64-encoded HTTP headers. Encoding these headers
+#' ensures that they can contain complex names with special characters.
+#'
+#' The function will warn if the decoded output string is no valid UTF-8. This
+#' might occur if the input was not base64 encoded.
+#'
+#' @param x A base64 encoded character string.
+#'
+#' @return A decoded character string.
+#' @noRd
+#'
+#' @examples
+#' encoded_username <- base64enc::base64encode(charToRaw("Ťěšťůšěř 的"))
+#' decode_base64(encoded_username)
+#' 
+decode_base64 <- function(
+    x
+){
+  if(is.null(x)) return(x)
+  stopifnot(is.character(x))
+  decoded <- base64enc::base64decode(x)
+  valid_UTF8 <- base64enc::checkUTF8(decoded, quiet = TRUE)
+  
+  if(isFALSE(valid_UTF8)){
+    warning(
+      "decoded string does not contain valid UTF-8. ",
+      "Is the input really base64 encoded?"
+    )
+    # using deparse creates visible quotes around the string but doing so will
+    # prevent the app from breaking due to incorrect UTF-8 encoding:
+    return({deparse1(rawToChar(decoded))})
+  }
+  rawToChar(decoded)
+}
+

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,6 +1,6 @@
 default:
   golem_name: clinsight
-  golem_version: 0.1.0.9005
+  golem_version: 0.1.0.9006
   app_prod: no
   user_identification: test_user
   study_data: !expr clinsight::clinsightful_data

--- a/tests/testthat/test-fct_utils.R
+++ b/tests/testthat/test-fct_utils.R
@@ -617,3 +617,28 @@ describe("expectation_type() works", {
     expect_error(expectation_type(expectation("failure", "f"), "non-existing expectation"))
   })
 })
+
+describe("decode_base64() works", {
+  it("converts a base64-encoded string with special characters as expected", {
+    testthat::skip_if_not_installed("base64enc")
+    #base64enc::base64encode(charToRaw("Ťěšťůšěř 的"))
+    expect_equal(
+      decode_base64("xaTEm8WhxaXFr8WhxJvFmSDnmoQ="), 
+      "Ťěšťůšěř 的"
+      )
+  })
+  it("returns NULL if the input is NULL", {
+    testthat::skip_if_not_installed("base64enc")
+    expect_null(decode_base64(NULL))
+  })
+  it("warns if decoded output is not a UTF-8 encoded string and 
+     returns a safe, quoted string in such a case", {
+    testthat::skip_if_not_installed("base64enc")
+    expect_warning(
+      output <- decode_base64("I am not encoded"),
+      paste0("decoded string does not contain valid UTF-8. ",
+             "Is the input really base64 encoded?")
+    )
+    expect_equal(output, "\"!\\xa9\\xa7\\xa2קr\\x87^\"")
+  })
+})


### PR DESCRIPTION
Closes #125. HTTP headers can only contain ascii signs, which causes issues when using names with less common names. Therefore, a solution is that user names are base64 encoded by the application serving the app (usually `shinyproxy`), and then decoded by clinsight once done.
