### PR TITLE
Give users ability to re-order columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.1.0.9004
+Version: 0.1.0.9005
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Generalized `merge_meta_with_data()` to allow user-defined processing functions.
 - Added a feature where, in applicable tables, a user can navigate to a form by double-clicking a table row.
 - Fixed warnings in `apply_edc_specific_changes` due to the use of a vector within `dplyr::select`.
+- Gave users ability to re-organized the column order in any table.
 
 # clinsight 0.1.0
 

--- a/R/fct_data_helpers.R
+++ b/R/fct_data_helpers.R
@@ -542,10 +542,10 @@ datatable_custom <- function(
     rename_vars = NULL, 
     title = NULL, 
     selection = "single",
-    extensions = "Scroller",
+    extensions = c("Scroller", "ColReorder"),
     plugins = "scrollResize",
     dom = "fti",
-    options = list(),
+    options = list(colReorder = TRUE),
     ...
     ){
   stopifnot(is.data.frame(data))

--- a/R/fct_data_helpers.R
+++ b/R/fct_data_helpers.R
@@ -528,6 +528,7 @@ add_missing_columns <- function(
 #'     * `deferREnder = TRUE`
 #'     * `scrollResize = TRUE`
 #'     * `scrollCollapse = TRUE`
+#'     * `colReorder = TRUE`
 #'   * Non-modifiable defaults:
 #'     * `dom`: Defined by the `dom` parameter.
 #'     * `initComplete`: Defaults to a function to insert table title into dataTable container.
@@ -545,7 +546,7 @@ datatable_custom <- function(
     extensions = c("Scroller", "ColReorder"),
     plugins = "scrollResize",
     dom = "fti",
-    options = list(colReorder = TRUE),
+    options = list(),
     ...
     ){
   stopifnot(is.data.frame(data))
@@ -563,7 +564,8 @@ datatable_custom <- function(
     scroller = TRUE,
     deferRender = TRUE,
     scrollResize = TRUE,
-    scrollCollapse = TRUE
+    scrollCollapse = TRUE,
+    colReorder = TRUE
   )
   fixed_opts <- list(
     initComplete = DT::JS(

--- a/man/datatable_custom.Rd
+++ b/man/datatable_custom.Rd
@@ -9,7 +9,7 @@ datatable_custom(
   rename_vars = NULL,
   title = NULL,
   selection = "single",
-  extensions = "Scroller",
+  extensions = c("Scroller", "ColReorder"),
   plugins = "scrollResize",
   dom = "fti",
   options = list(),
@@ -44,6 +44,7 @@ to 'fti' resulting in 'f<"header h5">ti'.}
 \item \code{deferREnder = TRUE}
 \item \code{scrollResize = TRUE}
 \item \code{scrollCollapse = TRUE}
+\item \code{colReorder = TRUE}
 }
 \item Non-modifiable defaults:
 \itemize{

--- a/tests/testthat/_snaps/app_feature_01/app-feature-1-001.json
+++ b/tests/testthat/_snaps/app_feature_01/app-feature-1-001.json
@@ -172,7 +172,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -182,6 +183,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -324,6 +326,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_01/app-feature-1-002.json
+++ b/tests/testthat/_snaps/app_feature_01/app-feature-1-002.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>Start date<\/th>\n      <th>End date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Category<\/th>\n      <th>Awareness date<\/th>\n      <th>Date of death<\/th>\n      <th>Death reason<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Serious Adverse Events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -184,6 +186,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -220,7 +239,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>start date<\/th>\n      <th>end date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Serious Adverse Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -230,6 +250,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Adverse events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -380,6 +401,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,
@@ -833,7 +871,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -843,6 +882,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -985,6 +1025,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_01/app-feature-1-003.json
+++ b/tests/testthat/_snaps/app_feature_01/app-feature-1-003.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>Start date<\/th>\n      <th>End date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Category<\/th>\n      <th>Awareness date<\/th>\n      <th>Date of death<\/th>\n      <th>Death reason<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Serious Adverse Events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -184,6 +186,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -220,7 +239,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>start date<\/th>\n      <th>end date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Serious Adverse Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -230,6 +250,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Adverse events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -380,6 +401,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,
@@ -8229,7 +8267,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -8239,6 +8278,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -8381,6 +8421,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_01/app-feature-1-004.json
+++ b/tests/testthat/_snaps/app_feature_01/app-feature-1-004.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>Start date<\/th>\n      <th>End date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Category<\/th>\n      <th>Awareness date<\/th>\n      <th>Date of death<\/th>\n      <th>Death reason<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Serious Adverse Events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -184,6 +186,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -220,7 +239,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>start date<\/th>\n      <th>end date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Serious Adverse Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -230,6 +250,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Adverse events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -380,6 +401,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,
@@ -8229,7 +8267,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Event<\/th>\n      <th>Systolic blood pressure<\/th>\n      <th>Diastolic blood pressure<\/th>\n      <th>Pulse<\/th>\n      <th>Resp<\/th>\n      <th>Temperature<\/th>\n      <th>Weight change since screening<\/th>\n      <th>BMI<\/th>\n      <th>Weight<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -8239,6 +8278,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -8395,6 +8435,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -8431,7 +8488,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -8441,6 +8499,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -8583,6 +8642,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_01/app-feature-1-005.json
+++ b/tests/testthat/_snaps/app_feature_01/app-feature-1-005.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>Start date<\/th>\n      <th>End date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Category<\/th>\n      <th>Awareness date<\/th>\n      <th>Date of death<\/th>\n      <th>Death reason<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Serious Adverse Events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -184,6 +186,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -220,7 +239,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>start date<\/th>\n      <th>end date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Serious Adverse Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -230,6 +250,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Adverse events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -380,6 +401,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,
@@ -8230,7 +8268,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Event<\/th>\n      <th>Systolic blood pressure<\/th>\n      <th>Diastolic blood pressure<\/th>\n      <th>Pulse<\/th>\n      <th>Resp<\/th>\n      <th>Temperature<\/th>\n      <th>Weight change since screening<\/th>\n      <th>BMI<\/th>\n      <th>Weight<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -8240,6 +8279,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -8396,6 +8436,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -8432,7 +8489,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -8442,6 +8500,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -8584,6 +8643,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_02/app-feature-2-001.json
+++ b/tests/testthat/_snaps/app_feature_02/app-feature-2-001.json
@@ -7279,7 +7279,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -7289,6 +7290,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -7431,6 +7433,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-001.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-001.json
@@ -7393,7 +7393,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -7403,6 +7404,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -7545,6 +7547,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-002.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-002.json
@@ -156,6 +156,21 @@
           }
         }
       ],
+      "ColReorder": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
       "scroller": {
         "topRow": 0,
         "baseScrollTop": 0,
@@ -289,6 +304,18 @@
             "caseInsensitive": true
           }
         }
+      ],
+      "ColReorder": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
       ],
       "scroller": {
         "topRow": 0,
@@ -433,7 +460,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>Start date<\/th>\n      <th>End date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Category<\/th>\n      <th>Awareness date<\/th>\n      <th>Date of death<\/th>\n      <th>Death reason<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -443,6 +471,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Serious Adverse Events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -611,6 +640,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -647,7 +693,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>N<\/th>\n      <th>Name<\/th>\n      <th>AESI<\/th>\n      <th>start date<\/th>\n      <th>end date<\/th>\n      <th>CTCAE severity<\/th>\n      <th>Treatment related<\/th>\n      <th>Treatment action<\/th>\n      <th>Other action<\/th>\n      <th>Serious Adverse Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -657,6 +704,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Adverse events\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -807,6 +855,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,
@@ -8368,7 +8433,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Status<\/th>\n      <th>Dx<\/th>\n      <th>Age<\/th>\n      <th>Sex<\/th>\n      <th>Event<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -8378,6 +8444,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -8520,6 +8587,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-003.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-003.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Type<\/th>\n      <th>Event<\/th>\n      <th>Form<\/th>\n      <th>Query<\/th>\n      <th>Time<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Open queries\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -162,6 +164,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -206,7 +225,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-hover row-border\">\n  <thead>\n    <tr>\n      <th>Query<\/th>\n      <th>Author<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -216,6 +236,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "<\"header h5\">t",
           "columnDefs": [
@@ -330,6 +351,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-004.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-004.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Type<\/th>\n      <th>Event<\/th>\n      <th>Form<\/th>\n      <th>Query<\/th>\n      <th>Time<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"Open queries\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -162,6 +164,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -206,7 +225,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-hover row-border\">\n  <thead>\n    <tr>\n      <th>Query<\/th>\n      <th>Author<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -216,6 +236,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "<\"header h5\">t",
           "columnDefs": [
@@ -330,6 +351,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-005.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-005.json
@@ -6,7 +6,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Resolved<\/th>\n      <th>Subject<\/th>\n      <th>Type<\/th>\n      <th>Event<\/th>\n      <th>Form<\/th>\n      <th>Query<\/th>\n      <th>Time<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -16,6 +17,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"All queries\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -166,6 +168,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -210,7 +229,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-hover row-border\">\n  <thead>\n    <tr>\n      <th>Query<\/th>\n      <th>Author<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -220,6 +240,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "<\"header h5\">t",
           "columnDefs": [
@@ -334,6 +355,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-001.json
+++ b/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-001.json
@@ -8,7 +8,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Form<\/th>\n      <th>summary_col<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -18,6 +19,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -142,6 +144,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-002.json
+++ b/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-002.json
@@ -8,7 +8,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Form<\/th>\n      <th>summary_col<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -18,6 +19,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -146,6 +148,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-003.json
+++ b/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-003.json
@@ -8,7 +8,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>Subject<\/th>\n      <th>ID<\/th>\n      <th>query<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -18,6 +19,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -142,6 +144,23 @@
           "all_files": false
         },
         {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
           "name": "dt-plugin-scrollresize",
           "version": "1.13.6",
           "src": {
@@ -178,7 +197,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>Subject<\/th>\n      <th>Form<\/th>\n      <th>summary_col<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -188,6 +208,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -316,6 +337,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/mod_report/mod_report-001.json
+++ b/tests/testthat/_snaps/mod_report/mod_report-001.json
@@ -91,6 +91,15 @@
           }
         }
       ],
+      "ColReorder": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
       "scroller": {
         "topRow": 0,
         "baseScrollTop": 0,
@@ -106,7 +115,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th>ID<\/th>\n      <th>Form<\/th>\n      <th>Event<\/th>\n      <th>Edit date<\/th>\n      <th>Reviewer<\/th>\n      <th>Time<\/th>\n      <th>comment<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -116,6 +126,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -250,6 +261,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/mod_study_forms/study_forms-001.json
+++ b/tests/testthat/_snaps/mod_study_forms/study_forms-001.json
@@ -1240,7 +1240,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>event_name<\/th>\n      <th>Systolic blood pressure<\/th>\n      <th>Diastolic blood pressure<\/th>\n      <th>Pulse<\/th>\n      <th>Resp<\/th>\n      <th>Temperature<\/th>\n      <th>Weight change since screening<\/th>\n      <th>BMI<\/th>\n      <th>Weight<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -1250,6 +1251,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -1400,6 +1402,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/_snaps/mod_study_forms/study_forms-002.json
+++ b/tests/testthat/_snaps/mod_study_forms/study_forms-002.json
@@ -1240,7 +1240,8 @@
         "filter": "none",
         "vertical": false,
         "extensions": [
-          "Scroller"
+          "Scroller",
+          "ColReorder"
         ],
         "container": "<table class=\"table table-striped table-hover row-border order-column display\">\n  <thead>\n    <tr>\n      <th> <\/th>\n      <th>event_name<\/th>\n      <th>Systolic blood pressure<\/th>\n      <th>Diastolic blood pressure<\/th>\n      <th>Pulse<\/th>\n      <th>Resp<\/th>\n      <th>Temperature<\/th>\n      <th>Weight change since screening<\/th>\n      <th>BMI<\/th>\n      <th>Weight<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
         "options": {
@@ -1250,6 +1251,7 @@
           "deferRender": true,
           "scrollResize": true,
           "scrollCollapse": true,
+          "colReorder": true,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -1400,6 +1402,23 @@
             "js/scroller.bootstrap5.min.js"
           ],
           "stylesheet": "css/scroller.bootstrap5.min.css",
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": false
+        },
+        {
+          "name": "dt-ext-colreorder-bootstrap5",
+          "version": "1.13.6",
+          "src": {
+            "href": "dt-ext-colreorder-bootstrap5-1.13.6"
+          },
+          "meta": null,
+          "script": [
+            "js/dataTables.colReorder.min.js",
+            "js/colReorder.bootstrap5.min.js"
+          ],
+          "stylesheet": "css/colReorder.bootstrap5.min.css",
           "head": null,
           "attachment": null,
           "package": null,


### PR DESCRIPTION
I don't think I ever opened an issue for this one here, but this is probably the most requested feature to `clinsight` for us. Kind of related to #96 because it reduces reliance on exporting to excel, when you can control the variable order in the app. I was too lazy to record a `gif`, but give it a run and you can now drag and drop columns for any table.

The only known issue with this extension is listed here: https://github.com/rstudio/DT/issues/250