### PR TITLE
Fix `pageLength` bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.1.1.9011
+Version: 0.1.1.9012
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 ## Bug fixes
 
 - The test-coverage GHA workflow is updated so that codecov uploads work again.
+- Display all rows for tables where `Scroller` is disabled.
 
 # clinsight 0.1.1
 

--- a/R/mod_navigate_review.R
+++ b/R/mod_navigate_review.R
@@ -153,7 +153,10 @@ mod_navigate_review_server <- function(
       datatable_custom(
         queries_table_data(), 
         rename_vars = table_names,
-        options = list(scroller = FALSE),
+        options = list(
+          scroller = FALSE,
+          pageLength = -1
+          ),
         rownames = FALSE,
         selection = "none"
         )

--- a/R/mod_queries.R
+++ b/R/mod_queries.R
@@ -173,7 +173,10 @@ mod_queries_server <- function(id, r, navinfo, all_forms, db_path, table_names){
         selected_query_data()[c("query", "reviewer")], 
         rename_vars = table_names,
         dom = 't',
-        options = list(scroller = FALSE),
+        options = list(
+          scroller = FALSE,
+          pageLength = -1
+        ),
         class = "row-border hover",
         rownames = FALSE,
         selection = "none"

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,6 +1,6 @@
 default:
   golem_name: clinsight
-  golem_version: 0.1.1.9011
+  golem_version: 0.1.1.9012
   app_prod: no
   user_identification: test_user
   study_data: !expr clinsight::clinsightful_data

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-003.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-003.json
@@ -237,6 +237,7 @@
           "scrollResize": true,
           "scrollCollapse": true,
           "colReorder": true,
+          "pageLength": -1,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "<\"header h5\">t",
           "columnDefs": [
@@ -254,6 +255,13 @@
           ],
           "autoWidth": false,
           "orderClasses": false,
+          "lengthMenu": [
+            -1,
+            10,
+            25,
+            50,
+            100
+          ],
           "ajax": {
             "type": "POST",
             "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = true;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-004.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-004.json
@@ -237,6 +237,7 @@
           "scrollResize": true,
           "scrollCollapse": true,
           "colReorder": true,
+          "pageLength": -1,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "<\"header h5\">t",
           "columnDefs": [
@@ -254,6 +255,13 @@
           ],
           "autoWidth": false,
           "orderClasses": false,
+          "lengthMenu": [
+            -1,
+            10,
+            25,
+            50,
+            100
+          ],
           "ajax": {
             "type": "POST",
             "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = true;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"

--- a/tests/testthat/_snaps/app_feature_03/app-feature-3-005.json
+++ b/tests/testthat/_snaps/app_feature_03/app-feature-3-005.json
@@ -241,6 +241,7 @@
           "scrollResize": true,
           "scrollCollapse": true,
           "colReorder": true,
+          "pageLength": -1,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "<\"header h5\">t",
           "columnDefs": [
@@ -258,6 +259,13 @@
           ],
           "autoWidth": false,
           "orderClasses": false,
+          "lengthMenu": [
+            -1,
+            10,
+            25,
+            50,
+            100
+          ],
           "ajax": {
             "type": "POST",
             "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = true;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"

--- a/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-003.json
+++ b/tests/testthat/_snaps/mod_navigate_review/test-mod_navigate_review-003.json
@@ -20,6 +20,7 @@
           "scrollResize": true,
           "scrollCollapse": true,
           "colReorder": true,
+          "pageLength": -1,
           "initComplete": "function() {\n$(this.api().table().container()).find('.header').html(\"\")\n}",
           "dom": "f<\"header h5\">ti",
           "columnDefs": [
@@ -41,6 +42,13 @@
           ],
           "autoWidth": false,
           "orderClasses": false,
+          "lengthMenu": [
+            -1,
+            10,
+            25,
+            50,
+            100
+          ],
           "ajax": {
             "type": "POST",
             "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = true;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"


### PR DESCRIPTION
The DataTable extension `Scroller` is disabled on a couple query tables, but the `pageLength` is still set at 10. This PR changes the `pageLength` to all rows. Typically there is not a lot of data in these tables, so enabling all rows shouldn't be a problem.