### PR TITLE
Fix shinytest2 for Chrome browsers in which the old headless mode is deprecated (v132 and higher)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.1.1.9016
+Version: 0.1.1.9017
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Make query handling a configurable option
 - Changed the legend to display 'significance pending' instead of 'significance unknown'.
 - Added `Excel` download button to Queries table & patient listings that need review.
+- (For developers) From now on,the new Chrome headless browser mode will be used for `shinytest2` tests so that unit tests can be run with Chrome v132. 
 
 ## Bug fixes
 

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,6 +1,6 @@
 default:
   golem_name: clinsight
-  golem_version: 0.1.1.9016
+  golem_version: 0.1.1.9017
   app_prod: no
   user_identification: test_user
   study_data: !expr clinsight::clinsightful_data

--- a/tests/testthat/setup-shinytest2.R
+++ b/tests/testthat/setup-shinytest2.R
@@ -1,2 +1,6 @@
+# Because the old headless mode is removed from chrome since v132.
+# Note: this setting is standard since R package chromote v0.4.0
+options(chromote.headless = "new")
+
 # Load application support files into testing environment
 if (FALSE) shinytest2::load_app_env()


### PR DESCRIPTION
Fixes issue described here: https://github.com/rstudio/chromote/issues/187 . Note that if we update the snapshot to 26Jan2025 or later, this additional line can be removed again since the setting is standard in Chromote v0.4.0 that just got released. 

https://github.com/rstudio/chromote/releases/tag/v0.4.0