### PR TITLE
remove even more unneeded reactivity in row review

### DIFF
--- a/R/mod_common_forms.R
+++ b/R/mod_common_forms.R
@@ -97,8 +97,16 @@ mod_common_forms_server <- function(
   moduleServer( id, function(input, output, session){
     ns <- session$ns
 
+    rev_data_form <- reactiveVal() 
+    observeEvent(r$review_data, {
+      rev_data_form_new <- with(r$review_data, r$review_data[item_group == form, ])
+      if(is.null(rev_data_form()) || !identical(rev_data_form(), rev_data_form_new)){
+        rev_data_form(rev_data_form_new)
+      }
+    })
+
     common_form_data <- reactive({
-      cat(form, "data computed \n")
+      golem::cat_dev(form, "data computed \n")
       shiny::validate(need(
         !is.null(r$filtered_data[[form]]),
         paste0("Warning: no data found in the database for the form '", form, "'.")
@@ -134,13 +142,16 @@ mod_common_forms_server <- function(
       } else {
         df
       }
-    })
-    if (form == "Adverse events")
+    }) |> 
+      bindEvent(r$filtered_data[[form]], rev_data_form(), r$subject_id)
+    
+    if (form == "Adverse events") {
       SAE_data <- reactive({
         shiny::validate(need(
           !is.null(r$filtered_data[[form]]),
           paste0("Warning: no data found in the database for the form '", form, "'.")
         ))
+        golem::cat_dev("SAE data computed \n")
         dplyr::left_join(
           r$filtered_data[[form]],
           with(r$review_data, r$review_data[item_group == form, ]) |>
@@ -172,11 +183,13 @@ mod_common_forms_server <- function(
               "SAE Awareness date", "SAE Date of death", "SAE Death reason")
           )) |>
           adjust_colnames("^SAE ")
-      })
-    
-    mod_review_form_tbl_server("review_form_tbl", r, common_form_data, form, reactive(input$show_all_data), table_names, form)
-    if (form == "Adverse events")
+      }) |> 
+        bindEvent(r$filtered_data[[form]], rev_data_form(), r$subject_id)
+      
       mod_review_form_tbl_server("review_form_SAE_tbl", r, SAE_data, form, reactive(input$show_all_data), table_names, "Serious Adverse Events")
+    }
+     
+    mod_review_form_tbl_server("review_form_tbl", r, common_form_data, form, reactive(input$show_all_data), table_names, form)
     
     mod_timeline_server(
       "timeline_fig", 

--- a/R/mod_common_forms.R
+++ b/R/mod_common_forms.R
@@ -129,7 +129,7 @@ mod_common_forms_server <- function(
         dplyr::mutate(o_reviewed = Map(\(x, y, z) append(x, list(
           row_id = y, 
           disabled = z,
-          updated = isolate(session$userData$update_checkboxes[[form]]))
+          updated = session$userData$update_checkboxes[[form]])
         ), 
         o_reviewed, 
         dplyr::row_number(),
@@ -169,7 +169,7 @@ mod_common_forms_server <- function(
           dplyr::mutate(o_reviewed = Map(\(x, y, z) append(x, list(
             row_id = y, 
             disabled = z,
-            updated = isolate(session$userData$update_checkboxes[[form]]))
+            updated = session$userData$update_checkboxes[[form]])
           ), 
           o_reviewed, 
           dplyr::row_number(),

--- a/R/mod_review_form_tbl.R
+++ b/R/mod_review_form_tbl.R
@@ -61,6 +61,16 @@ mod_review_form_tbl_server <- function(
     
     ############################### Observers: #################################
     
+    # table data manipulation code should ideally be here, then we can remove this.
+    # Alternatively, we can also pass this from the main module as a function argument
+    rev_data_form <- reactiveVal() 
+    observeEvent(r$review_data, {
+      rev_data_form_new <- with(r$review_data, r$review_data[item_group == form, ])
+      if(is.null(rev_data_form()) || !identical(rev_data_form(), rev_data_form_new)){
+        rev_data_form(rev_data_form_new)
+      }
+    })
+    
     observe({
       golem::cat_dev(form, "| Resetting userData\n")
       reload_data(reload_data() + 1)
@@ -68,7 +78,7 @@ mod_review_form_tbl_server <- function(
       session$userData$update_checkboxes[[form]] <- NULL
       session$userData$review_records[[form]] <- data.frame(id = integer(), reviewed = character())
     }) |> 
-      bindEvent(r$subject_id, r$review_data, r$filtered_data[[form]])
+      bindEvent(r$subject_id, rev_data_form(), r$filtered_data[[form]])
     
     observeEvent(datatable_rendered(), {
       table_data(reactive_table_data())

--- a/R/mod_review_forms.R
+++ b/R/mod_review_forms.R
@@ -137,6 +137,7 @@ mod_review_forms_server <- function(
       bindEvent(active_form(), session$userData$review_records[[active_form()]])
     
     observeEvent(r$subject_id, {
+      golem::cat_dev("mod_review_forms | Reset review records\n")
       session$userData$update_checkboxes[[active_form()]] <- NULL
       session$userData$review_records[[active_form()]] <- data.frame(id = integer(), reviewed = character())
     })

--- a/R/mod_review_forms.R
+++ b/R/mod_review_forms.R
@@ -159,8 +159,6 @@ mod_review_forms_server <- function(
     observeEvent(c(active_form(), r$subject_id), {
       cat("Update confirm review button\n\n\n")
       req(r$review_data)
-      golem::cat_dev("review_data_active:\n")
-      golem::print_dev(review_data_active())
       review_indeterminate(FALSE)
       if(nrow(review_data_active()) == 0){ 
         cat("No review data found for Subject id: ", r$subject_id, 
@@ -271,10 +269,12 @@ mod_review_forms_server <- function(
           status      = ifelse(reviewed == "Yes", "old", "new")
         ) 
       
-      golem::cat_dev("review records to add:\n")
-      golem::print_dev(review_records)
+      golem::cat_dev(
+        active_form(), "|", "Adjusting review status for", 
+        length(unique(review_records$id)), "ids\n" 
+      )
       
-      cat("write review progress to database\n")
+      cat("Writing review progress to database\n")
       db_save_review(
         review_records, 
         db_path = db_path,

--- a/R/mod_study_forms.R
+++ b/R/mod_study_forms.R
@@ -146,6 +146,14 @@ mod_study_forms_server <- function(
       shinyjs::disable("switch_view")
     }
     
+    rev_data_form <- reactiveVal() 
+    observeEvent(r$review_data, {
+      rev_data_form_new <- with(r$review_data, r$review_data[item_group == form, ])
+      if(is.null(rev_data_form()) || !identical(rev_data_form(), rev_data_form_new)){
+        rev_data_form(rev_data_form_new)
+      }
+    })
+    
     fig_data <- reactive({
       req(isTRUE(all_continuous))
       validate(need(
@@ -191,7 +199,9 @@ mod_study_forms_server <- function(
         o_reviewed, 
         dplyr::row_number(),
         subject_id != r$subject_id))
-    })
+    }) |> 
+      bindEvent(r$filtered_data[[form]], rev_data_form(), r$subject_id)
+    
     mod_review_form_tbl_server("review_form_tbl", r, study_form_data, form, reactive(input$show_all), table_names)
     
     scaling_data <- reactive({

--- a/R/mod_study_forms.R
+++ b/R/mod_study_forms.R
@@ -194,7 +194,7 @@ mod_study_forms_server <- function(
         dplyr::mutate(o_reviewed = Map(\(x, y, z) append(x, list(
           row_id = y, 
           disabled = z,
-          updated = isolate(session$userData$update_checkboxes[[form]]))
+          updated = session$userData$update_checkboxes[[form]])
         ), 
         o_reviewed, 
         dplyr::row_number(),


### PR DESCRIPTION
@jthompson-arcus is this something?

Note that this now also keeps userData of form x if only userData was saved from form y, which can be nice I think