### PR TITLE
Small fix: add missing semicolon

### DIFF
--- a/dev/build_pdf_manual.R
+++ b/dev/build_pdf_manual.R
@@ -24,7 +24,7 @@ build_manual_custom <- function (pkg = ".", path = NULL){
     fail_on_status = TRUE, 
     stderr = "2>&1", 
     spinner = FALSE), 
-    error = function(e) { print(e) cli::cli_abort("Failed to build manual")}
+    error = function(e) { print(e); cli::cli_abort("Failed to build manual")}
     )
   cat(msg$stdout)
   invisible(msg)


### PR DESCRIPTION
_Hi 👋, adding a small fix. Thanks!_

**PR Description**
This pull request includes a small change to the [`dev/build_pdf_manual.R`](https://github.com/openpharma/clinsight/blob/main/dev/build_pdf_manual.R) file. The change ensures proper syntax by adding a semicolon to separate the `print(e)` and `cli::cli_abort("Failed to build manual")` statements in the error handling function.


