### PR TITLE
Acknowledge `edit_date_time` values during `db_update()`

### DIFF
--- a/R/mod_review_data_fct_helpers.R
+++ b/R/mod_review_data_fct_helpers.R
@@ -91,6 +91,10 @@ update_review_data <- function(
     # including event_date in join by should work, even for Adverse events, since 
     # if event_date changes, the edit date-time also changes, and thus all rows 
     # will be taken into consideration.
+    dplyr::left_join(review_df, by = key_cols, suffix = c("", ".old")) |>
+    dplyr::filter(is.na(.data[[paste0(edit_time_var, ".old")]]) | 
+                    .data[[edit_time_var]] > .data[[paste0(edit_time_var, ".old")]]) |>
+    dplyr::select(dplyr::all_of(names(latest_review_data))) |>
     dplyr::full_join(review_df, by = names(latest_review_data)) |> 
     add_missing_columns(c("timestamp", "reviewed", "comment", "status"))
   


### PR DESCRIPTION
PR to `update_review_data()` that only consider updating records with a new `edit_date_time` that are more recent than the "old" `edit_date_time` to determine if the data should be considered new/updated.

Why do we need this? We're going to be changing a bunch of `edit_date_time` values for a study that has a production app deployed. Right now, if we attempt to update the db with the new `merged_data` object, it marks all those records as needing review. However, if some records get a new `edit_date_time` from a prior date, we want it to retain the previous review completed.

Originally authored by @jthompson-arcus! I can't take any credit. We covet your thoughts @LDSamson!