### PR TITLE
Improve `add_row_review_status()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.3.0.9000
+Version: 0.3.0.9001
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # clinsight (development version)
 
+## Changed
+
+- Replaced `dplyr::case_when()` with `ifelse()` in the row review status calculation for efficiency
+
 # clinsight 0.3.0
 
 ## Developer notes

--- a/R/fct_tables.R
+++ b/R/fct_tables.R
@@ -88,10 +88,12 @@ create_table.default <- function(
 add_row_review_status <- function(data, id_cols) {
   dplyr::mutate(
     data,
-    row_review_status = dplyr::case_when(
-      any(reviewed == "No") & any(reviewed == "Yes") ~ list(list(reviewed = NA, ids = id)),
-      any(reviewed == "Yes") ~ list(list(reviewed = TRUE, ids = id)),
-      .default = list(list(reviewed = FALSE, ids = id))
+    row_review_status = ifelse(
+      any(reviewed == "No") & any(reviewed == "Yes"), list(list(reviewed = NA, ids = id)),
+      ifelse(
+        any(reviewed == "Yes"), list(list(reviewed = TRUE, ids = id)),
+        list(list(reviewed = FALSE, ids = id))
+      )
     ),
     .by = dplyr::all_of(id_cols))
 }

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,6 +1,6 @@
 default:
   golem_name: clinsight
-  golem_version: 0.3.0
+  golem_version: 0.3.0.9001
   app_prod: no
   user_identification: test_user
   study_data: !expr clinsight::clinsightful_data


### PR DESCRIPTION
We have found that `ifelse()` is way more efficient than `dplyr::case_when()` (by order of 2x as fast). This becomes more critical as data increases in size. We have tables where the current process can take upwards of 3 seconds to calculate. This small change moves that number closer to 1 second.