### PR TITLE
Fix error in figures if no data is available for selected subject and `show_all_participants` is `FALSE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.3.0.9009
+Version: 0.3.0.9010
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/R/fct_figures.R
+++ b/R/fct_figures.R
@@ -234,7 +234,7 @@ fig_timeseries <- function(
     ggplot2::facet_wrap(~item_name, ncol = 2, scales = "free_y") +
     ggplot2::scale_fill_manual(values = col_palette) +
     ggplot2::scale_x_continuous(limits = \(x){
-      if(length(x) == 0) return(c(0,1))
+      if(length(x) == 0) return(c(0,3))
       c(
         pmin(x[1], 0), # Always include day zero. 
         pmax(x[2], 3) # keeps minimum scale of 3 days if not much data is available

--- a/R/fct_figures.R
+++ b/R/fct_figures.R
@@ -234,6 +234,7 @@ fig_timeseries <- function(
     ggplot2::facet_wrap(~item_name, ncol = 2, scales = "free_y") +
     ggplot2::scale_fill_manual(values = col_palette) +
     ggplot2::scale_x_continuous(limits = \(x){
+      if(length(x) == 0) return(c(0,1))
       c(
         pmin(x[1], 0), # Always include day zero. 
         pmax(x[2], 3) # keeps minimum scale of 3 days if not much data is available

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,6 +1,6 @@
 default:
   golem_name: clinsight
-  golem_version: 0.3.0.9009
+  golem_version: 0.3.0.9010
   app_prod: no
   user_identification: test_user
   study_data: !expr clinsight::clinsightful_data

--- a/tests/testthat/test-fig_timeseries.R
+++ b/tests/testthat/test-fig_timeseries.R
@@ -81,5 +81,31 @@ describe(
       )
     })
     
+    it("returns empty plot if no data available for id to highlight and show_all_participants is FALSE", {
+      expect_no_error({
+        fig <- fig_timeseries(
+          mock_data, 
+          id_to_highlight = "non-existent", 
+          show_all_participants = FALSE
+        )
+      })
+      plotlayers <- get_ggplot_layer_names(fig)
+      expect_null(plotlayers)
+      expect_equal(mock_data, fig$data)
+      
+      expect_no_error({
+        fig2 <- fig_timeseries(
+          mock_data, 
+          id_to_highlight = "non-existent", 
+          show_all_participants = FALSE, 
+          yval = "value_scaled"
+        )
+      })
+      
+      plotlayers <- get_ggplot_layer_names(fig2)
+      expect_equal(plotlayers, c("geom_hline", "geom_hline"))
+      expect_equal(mock_data, fig2$data)
+    })
+    
   }
 )


### PR DESCRIPTION
To reproduce, browse to subject `NL_05_282` in the current `dev` version and view the `Electrolytes`  tab. The following error shows up:

<img width="1685" height="426" alt="grafik" src="https://github.com/user-attachments/assets/cc29e45d-50af-4834-8329-19016e5310b2" />


This fix is easy, just one additional line and it looks again as desired:
<img width="1684" height="653" alt="grafik" src="https://github.com/user-attachments/assets/54ac8269-daa3-4280-90b1-a62cea231629" />

I did not add a news item since this bug was introduced in PR #249, and thus only existed in the `dev` version. Happy to add some if you think it is needed, no strong feelings about that

GAMP V Low-risk priority because it is a non-fatal error, clearly visible, and usability is not compromised.