### PR TITLE
Add `origin` arg to `as.Date()` in `get_timeline_data()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: clinsight
 Title: ClinSight
-Version: 0.3.0.9014
+Version: 0.3.0.9015
 Authors@R: c(
     person("Leonard Daniël", "Samson", , "lsamson@gcp-service.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-6252-7639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 ## Bug fixes 
 
 - [fix_multiple_choice_vars()] now also fixes long-format multiple choice variables that end with a number (#247).
+- Added date origin to `as.Date()` in `get_timeline_data()` that Posit Connect couldn't handle without.
 
 ## Developer notes
 

--- a/R/fct_appdata_summary_tables.R
+++ b/R/fct_appdata_summary_tables.R
@@ -109,7 +109,7 @@ get_timeline_data <- function(
         ),
         start = ifelse(is.na(`SAE Start date`), clean_dates(`start date`), 
                        clean_dates(`SAE Start date`)) |> 
-          as.Date(),
+          as.Date(origin = "1970-01-01"),
         end = clean_dates(`SAE End date`),
         className = "bg-danger",
         title = paste0(

--- a/tests/testthat/test-mod_header_widgets.R
+++ b/tests/testthat/test-mod_header_widgets.R
@@ -297,7 +297,7 @@ describe(
         expect_true(app$get_js(timeline_visibile))
         
         app$set_inputs("main_tabs" = "Study data")
-        app$wait_for_idle()
+        app$wait_for_idle(800)
         expect_false(app$get_js(timeline_visibile))
         
         app$run_js('$("#sf_toggle_timeline").click()')


### PR DESCRIPTION
Posit Connect was throwing a fit with this line of code for some reason. Issue resolve with the following change.